### PR TITLE
Run bundler audit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ group :production do
 end
 
 group :development do
+  gem 'bundler-audit'
   gem 'listen', '~> 3.0.5'
   gem 'spring'
   gem 'spring-commands-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,9 @@ GEM
     bindex (0.5.0)
     brakeman (4.3.0)
     builder (3.2.3)
+    bundler-audit (0.6.0)
+      bundler (~> 1.2)
+      thor (~> 0.18)
     byebug (10.0.2)
     capybara (2.10.2)
       addressable
@@ -349,6 +352,7 @@ DEPENDENCIES
   airbrake (~> 6.2)
   american_date
   brakeman
+  bundler-audit
   byebug
   capybara (~> 2.10.1)
   carrierwave (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,7 +193,7 @@ GEM
     rack (2.0.5)
     rack-attack (5.2.0)
       rack
-    rack-protection (2.0.1)
+    rack-protection (2.0.3)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -293,10 +293,10 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sinatra (2.0.1)
+    sinatra (2.0.3)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.1)
+      rack-protection (= 2.0.3)
       tilt (~> 2.0)
     sorcerer (1.0.2)
     spring (2.0.2)

--- a/lib/tasks/bundler_audit.rake
+++ b/lib/tasks/bundler_audit.rake
@@ -1,0 +1,2 @@
+require 'bundler/audit/task'
+Bundler::Audit::Task.new


### PR DESCRIPTION
Resolves #20 <!--fill issue number-->

### Description

#### First commit

On the recommendation of the inestimable @robbkidd, added the `rake bundle:audit` task.

#### Second commit

Upgraded sinatra sub-dependency to 2.0.3 to resolve a possible vulnerability reported by `bundler-audit`.

### Type of change

* Bug (security) fix
* New feature (new tooling: `bundler-audit`)