### PR TITLE
Add checkbox to invite user form for regional admins.

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -3,7 +3,7 @@ class InvitationsController < Devise::InvitationsController
   before_action :require_admin, only: %i[new create]
   before_action :require_access_to_community, only: %i[new create]
   before_action :update_sanitized_params, only: :update
-  before_action :allow_community_id, only: :create
+  before_action :allow_devise_params, only: :create
 
   ## This is a devise invitable method that I needed to overwrite, unfortunately
   ## because of the way they implemented the 'redirect' on success (they used respond_with)
@@ -35,12 +35,13 @@ class InvitationsController < Devise::InvitationsController
                                                phone
                                                password
                                                password_confirmation
+                                               remote_clinic_lawyer
                                                invitation_token
                                                volunteer_type
                                                pledge_signed])
   end
 
-  def allow_community_id
-    devise_parameter_sanitizer.permit(:invite, keys: [:community_id])
+  def allow_devise_params
+    devise_parameter_sanitizer.permit(:invite, keys: [:community_id, :remote_clinic_lawyer])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,7 +28,8 @@ class UsersController < ApplicationController
       :email,
       :phone,
       :volunteer_type,
-      :pledge_signed
+      :pledge_signed,
+      :remote_clinic_lawyer
     )
   end
 

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -10,6 +10,12 @@
         <%= f.text_field field, class: 'form-control' %>
       </div>
     <% end -%>
+    <% if current_user.regional_admin? %>
+      <div class='form-check'>
+        <%= f.check_box :remote_clinic_lawyer, {class: 'form-check-input'}, true , false %>
+        <%= f.label :remote_clinic_lawyer, "Remote Clinic Lawyer?", {class: 'form-check-label'} %>
+      </div>
+      <% end %>
     <%= f.hidden_field :community_id, value: current_community.id %>
     <p><%= f.submit t('devise.invitations.new.submit_button'), class: 'btn btn-primary' %></p>
   <% end %>

--- a/spec/features/invite_a_new_user_spec.rb
+++ b/spec/features/invite_a_new_user_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Admin invites a new user', type: :feature do
 
   let(:admin) { create(:user, :community_admin, community: community) }
+  let(:regional_admin) { create(:user, :regional_admin, community: community) }
   let(:community) { create(:community) }
   let(:email) { FFaker::Internet.email }
 
@@ -20,11 +21,24 @@ RSpec.describe 'Admin invites a new user', type: :feature do
       end
     end
 
+    it 'does not display the remote clinic lawyer checkbox' do
+      expect(page).to_not have_content('Remote Clinic Lawyer')
+    end
+
     it 'sends the invitation' do
       expect{ click_button 'Send an invitation' }.to change(ActionMailer::Base.deliveries, :count).by(1)
     end
   end
-
+  describe 'remote admin inviting a new user' do
+    before do
+      login_as(regional_admin)
+      visit new_user_community_invitation_path(community)
+      fill_in 'Email', with: email
+    end
+    it 'does display the remote clinic lawyer checkbox' do
+      expect(page).to have_content('Remote Clinic Lawyer')
+    end
+  end
   describe 'user accepting an invitation' do
     before do
       login_as(admin)


### PR DESCRIPTION
## What

Created a checkbox on the invitation form :/users/communities/nyc/invitation/new that will only appear for regional_admins. 

## How 

Visit /users/communities/nyc/invitation/new as a regional_admin and see the new checkbox.
Visit /users/communities/nyc/invitation/new as a non-regional admin and you will not see it.

## Why
#3 

