### PR TITLE
Don't load bundler audit in prod

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :assets do
 end
 
 group :development, :test do
+  gem 'bundler-audit'
   gem 'byebug'
   gem 'capybara', '~> 2.10.1', require: false
   gem 'database_cleaner', '~> 1.5.3', require: false
@@ -61,7 +62,6 @@ group :production do
 end
 
 group :development do
-  gem 'bundler-audit'
   gem 'listen', '~> 3.0.5'
   gem 'spring'
   gem 'spring-commands-rspec'

--- a/lib/tasks/bundler_audit.rake
+++ b/lib/tasks/bundler_audit.rake
@@ -1,2 +1,4 @@
-# require 'bundler/audit/task'
-# Bundler::Audit::Task.new
+if Rails.env.development? || Rails.env.test?
+  require 'bundler/audit/task'
+  Bundler::Audit::Task.new
+end


### PR DESCRIPTION
Also, moved `bundler-audit` from deveploment to development+test group
in Gemfile.

### Type of change

* Bug fix

### How Has This Been Tested?

Ran `circleci build` locally and succeeded.