### PR TITLE
add remote field to user_friend_association and update seed

### DIFF
--- a/app/models/friend.rb
+++ b/app/models/friend.rb
@@ -79,6 +79,10 @@ class Friend < ApplicationRecord
       .where(applications: { status: [:in_review, :changes_requested, :approved] })
   }
 
+  def remote_clinic_lawyers
+    users.where(user_friend_associations: { remote: true })
+  end
+
   def name
     "#{first_name} #{last_name}"
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,10 @@ class User < ApplicationRecord
 
   scope :remote_lawyers, -> { where(remote_clinic_lawyer: true) }
 
+  def remote_clinic_friends
+    friends.where(user_friend_associations: { remote: true })
+  end
+
   def confirmed?
     invitation_accepted_at.present?
   end

--- a/db/migrate/20180610160526_add_remote_to_user_friends_association.rb
+++ b/db/migrate/20180610160526_add_remote_to_user_friends_association.rb
@@ -1,0 +1,5 @@
+class AddRemoteToUserFriendsAssociation < ActiveRecord::Migration[5.0]
+  def change
+    add_column :user_friend_associations, :remote, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180610140434) do
+ActiveRecord::Schema.define(version: 20180610160526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -282,10 +282,11 @@ ActiveRecord::Schema.define(version: 20180610140434) do
   end
 
   create_table "user_friend_associations", force: :cascade do |t|
-    t.integer  "user_id",    null: false
-    t.integer  "friend_id",  null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer  "user_id",                    null: false
+    t.integer  "friend_id",                  null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.boolean  "remote",     default: false
     t.index ["friend_id"], name: "index_user_friend_associations_on_friend_id", using: :btree
     t.index ["user_id"], name: "index_user_friend_associations_on_user_id", using: :btree
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,10 +43,13 @@ User.create(first_name: 'NYC Community', last_name: 'Volunteer', email: 'nyc_vol
 User.create(first_name: 'NYC Community', last_name: 'Admin', email: 'nyc_admin@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 2, pledge_signed: true)
 
 #Some additional NYC volunteer users
-30.times do
+20.times do
   User.create(first_name: FFaker::Name.first_name, last_name: FFaker::Name.last_name, email: FFaker::Internet.safe_email, community_id: nyc_community.id, phone: FFaker::PhoneNumber.short_phone_number, password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 0, pledge_signed: true)
 end
 
+10.times do
+  User.create(first_name: FFaker::Name.first_name, last_name: FFaker::Name.last_name, email: FFaker::Internet.safe_email, community_id: nyc_community.id, phone: FFaker::PhoneNumber.short_phone_number, password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 2, role: 0, pledge_signed: true, remote_clinic_lawyer: [true, false].shuffle)
+end
 ## Long Island Users
 
 #Accompaniment Leader User
@@ -94,7 +97,7 @@ end
 
 # Long Islang Friends
 30.times do
-  Friend.create(first_name: FFaker::Name.first_name,
+  friend = Friend.create(first_name: FFaker::Name.first_name,
     last_name: FFaker::Name.last_name,
     a_number: rand.to_s[2..10],
     community_id: long_island_community.id,
@@ -119,6 +122,10 @@ end
     language_ids: [Language.order("RANDOM()").first.id],
     user_ids: User.where(community_id: long_island_community.id).order("RANDOM()").limit(5).map(&:id)
     )
+
+  friend.user_friend_associations.each do |assoc|
+    assoc.update_attributes(remote: [true, false].sample)
+  end
 end
 
 #Lawyers


### PR DESCRIPTION
## What
Migration to add `remote` field to `user_friend_associations` table that represents a remote relationship between a lawyer user and friend.

## Why
#17 We need to know if a relationship is in-person or remote before we can create the view.