### PR TITLE
16 regadmin assigns lawyer

### DIFF
--- a/app/controllers/regional_admin/friends_controller.rb
+++ b/app/controllers/regional_admin/friends_controller.rb
@@ -1,5 +1,5 @@
 class RegionalAdmin::FriendsController < RegionalAdminController
-  before_action :find_friend, only: [:show, :assign_friendship]
+  before_action :find_friend, only: [:show, :update]
 
   def index
     @friends = current_region.friends.with_active_applications.with_assigned_lawyers.order('last_name asc')
@@ -7,18 +7,40 @@ class RegionalAdmin::FriendsController < RegionalAdminController
 
   def show; end
 
-  def assign_friendship
-    if lawyer = User.find_by(id: params[:user][:id])
-      @friend.user_friend_associations.create(user_id: lawyer.id, remote: true)
-      flash[:notice] = "An invitation email has been sent to #{lawyer.email}."
-      redirect_to regional_admin_region_friend_path(@friend)
+  def update
+    if @friend.update_attributes(user_friend_associations_params)
+      flash[:success] = 'Changes successfully saved.'
+    else
+      flash[:error] = 'Something went wrong. Please try again.'
     end
-  rescue
-    flash.now[:error] = "Something went wrong. Please try again."
-    redirect_to regional_admin_region_friend_path(@friend)
+    redirect_to regional_admin_region_friend_path(current_region, @friend)
   end
 
-  private def find_friend
+  private
+
+  def find_friend
     @friend = Friend.find_by(id: params[:id])
+  end
+
+  def user_friend_associations_params
+    persisted_lawyer_ids = @friend.remote_clinic_lawyers.map(&:id)
+    lawyer_ids_params = friend_params[:user_ids].map{ |id| id.to_i if id.present? }.compact
+    added_lawyer_ids = lawyer_ids_params - persisted_lawyer_ids
+    removed_lawyer_ids = persisted_lawyer_ids - lawyer_ids_params
+
+    user_friend_associations_attributes = []
+    added_lawyer_ids.each do |user_id|
+      user_friend_associations_attributes << { user_id: user_id, friend_id: @friend.id, remote: true }
+    end
+
+    removed_lawyer_ids.each do |user_id|
+      id = UserFriendAssociation.where(user_id: user_id, friend_id: @friend.id, remote: true).first.id
+      user_friend_associations_attributes << { id: id, _destroy: '1' }
+    end
+    { user_friend_associations_attributes: user_friend_associations_attributes }
+  end
+
+  def friend_params
+    params.require(:friend).permit(user_ids: [])
   end
 end

--- a/app/controllers/regional_admin/friends_controller.rb
+++ b/app/controllers/regional_admin/friends_controller.rb
@@ -1,9 +1,24 @@
 class RegionalAdmin::FriendsController < RegionalAdminController
+  before_action :find_friend, only: [:show, :assign_friendship]
+
   def index
     @friends = current_region.friends.with_active_applications.with_assigned_lawyers.order('last_name asc')
   end
 
-  def show
-    @friend = Friend.find(params[:id])
+  def show; end
+
+  def assign_friendship
+    if lawyer = User.find_by(id: params[:user][:id])
+      @friend.user_friend_associations.create(user_id: lawyer.id, remote: true)
+      flash[:notice] = "An invitation email has been sent to #{lawyer.email}."
+      redirect_to regional_admin_region_friend_path(@friend)
+    end
+  rescue
+    flash.now[:error] = "Something went wrong. Please try again."
+    redirect_to regional_admin_region_friend_path(@friend)
+  end
+
+  private def find_friend
+    @friend = Friend.find_by(id: params[:id])
   end
 end

--- a/app/mailers/friendship_assignment_mailer.rb
+++ b/app/mailers/friendship_assignment_mailer.rb
@@ -1,0 +1,8 @@
+class FriendshipAssignmentMailer < Devise::Mailer
+  default template_path: 'devise/mailer/friendships'
+
+  def send_assignment(user, friend)
+    @friend = friend
+    mail to: user.email, subject: 'Friend assignment'
+  end
+end

--- a/app/models/friend.rb
+++ b/app/models/friend.rb
@@ -61,6 +61,8 @@ class Friend < ApplicationRecord
   has_many :inverse_partner_relationships, class_name: 'PartnerRelationship', foreign_key: 'partner_id', dependent: :destroy
   has_many :inverse_partners, through: :inverse_partner_relationships, source: :friend
 
+  accepts_nested_attributes_for :user_friend_associations, allow_destroy: true
+
   validates :first_name, :last_name, :community_id, :region_id, presence: true
   validates :zip_code, length: { is: 5 }, allow_blank: true, numericality: true
   validates :a_number, presence: { if: :a_number_available? }, numericality: { if: :a_number_available? }

--- a/app/models/user_friend_association.rb
+++ b/app/models/user_friend_association.rb
@@ -5,6 +5,6 @@ class UserFriendAssociation < ApplicationRecord
   after_create :remote_lawyer_invitation, if: Proc.new { |friendship| friendship.remote? }
 
   def remote_lawyer_invitation
-    User.invite!(email: self.user.email)
+    FriendshipAssignmentMailer.send_assignment(user, friend)
   end
 end

--- a/app/models/user_friend_association.rb
+++ b/app/models/user_friend_association.rb
@@ -1,4 +1,10 @@
 class UserFriendAssociation < ApplicationRecord
   belongs_to :user
   belongs_to :friend
+
+  after_create :remote_lawyer_invitation, if: Proc.new { |friendship| friendship.remote? }
+
+  def remote_lawyer_invitation
+    User.invite!(email: self.user.email)
+  end
 end

--- a/app/views/devise/mailer/friendships/send_assignment.html.erb
+++ b/app/views/devise/mailer/friendships/send_assignment.html.erb
@@ -1,0 +1,3 @@
+<p>Welcome New Sanctuary Coalition Volunteer!</p>
+
+You have been assigned to review <%= @friend.first_name %>'s applications

--- a/app/views/devise/mailer/friendships/send_assignment.text.erb
+++ b/app/views/devise/mailer/friendships/send_assignment.text.erb
@@ -1,0 +1,3 @@
+Welcome New Sanctuary Coalition Volunteer!
+
+You have been assigned to review <%= @friend.first_name %>'s applications

--- a/app/views/regional_admin/friends/show.html.erb
+++ b/app/views/regional_admin/friends/show.html.erb
@@ -1,38 +1,42 @@
 <h1><%= link_to @friend.name, edit_community_admin_friend_path(@friend.community.slug, @friend) %></h1>
-  <% @friend.grouped_drafts.each do |group| %>
-    <h3><%= group[:name].titlecase %></h3>
-    <% group[:drafts].each do |draft| %>
-      <div class='row'>
-        <div class='col-md-9'>
-          <p>
-            <%= link_to draft.pdf_draft.file.filename, draft.pdf_draft_url, target: '_blank' %>
-            <%= draft.created_at.strftime("-- %A, %B %-d, %Y") %><br>
 
-            <% if draft.users.present? %>
-              <strong>Team:  </strong><%= draft.users.map(&:name).to_sentence %><br>
-            <% end %>
-
-            <% if draft.notes.present? %>
-              <strong>Notes:  </strong><%= draft.notes %><br>
-            <% end %>
-          </p>
-        </div>
-        <div class='col-md-3 text-muted'>
-          <%= draft.status_string %> <%= draft.updated_at.strftime('%m/%d/%Y') %>
-        </div>
-    </div>
-  <% end %>
-
-
-  <%= form_tag assign_friendship_regional_admin_region_friend_path, method: :post, class: 'col-md-3 col-xs-12 control-label' do |f| %>
-    <div class="field">
-      <%= label_tag :id, 'Assigned Lawyer', class: 'col-xs-12 control-label' %>
+<% @friend.grouped_drafts.each do |group| %>
+  <h3><%= group[:name].titlecase %></h3>
+  <% group[:drafts].each do |draft| %>
+    <div class='row'>
       <div class='col-md-9'>
-        <%= collection_select(:user, :id, User.remote_lawyers, :id, :name, {include_blank: true, class: 'form-control' }) %>
+        <p>
+          <%= link_to draft.pdf_draft.file.filename, draft.pdf_draft_url, target: '_blank' %>
+          <%= draft.created_at.strftime("-- %A, %B %-d, %Y") %><br>
+
+          <% if draft.users.present? %>
+            <strong>Team:  </strong><%= draft.users.map(&:name).to_sentence %><br>
+          <% end %>
+
+          <% if draft.notes.present? %>
+            <strong>Notes:  </strong><%= draft.notes %><br>
+          <% end %>
+        </p>
       </div>
-    </div>
-    <div class="actions">
-      <%= submit_tag "Save" %>
+      <div class='col-md-3 text-muted'>
+        <%= draft.status_string %> <%= draft.updated_at.strftime('%m/%d/%Y') %>
+      </div>
     </div>
   <% end %>
 <% end %>
+
+
+
+<h3>Assigned Lawyers</h3>
+<div class='row form-group'>
+  <%= form_for [:regional_admin, current_region, @friend] do |f| %>
+    <%= fields_for @friend.user_friend_associations do |fl| %>
+      <div class='col-md-6'>
+        <%= collection_select(:friend, :user_ids, User.remote_lawyers, :id, :name, {selected: @friend.remote_clinic_lawyers.map(&:id)}, {multiple: true, prompt: true, class: 'chzn-select form-control'}) %>
+      </div>
+    <% end %>
+
+    <%= f.submit 'Save', class: 'btn btn-primary' %>
+  <% end %>
+</div>
+

--- a/app/views/regional_admin/friends/show.html.erb
+++ b/app/views/regional_admin/friends/show.html.erb
@@ -22,4 +22,17 @@
         </div>
     </div>
   <% end %>
+
+
+  <%= form_tag assign_friendship_regional_admin_region_friend_path, method: :post, class: 'col-md-3 col-xs-12 control-label' do |f| %>
+    <div class="field">
+      <%= label_tag :id, 'Assigned Lawyer', class: 'col-xs-12 control-label' %>
+      <div class='col-md-9'>
+        <%= collection_select(:user, :id, User.remote_lawyers, :id, :name, {include_blank: true, class: 'form-control' }) %>
+      </div>
+    </div>
+    <div class="actions">
+      <%= submit_tag "Save" %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/regional_admin/remote_lawyers/edit.html.erb
+++ b/app/views/regional_admin/remote_lawyers/edit.html.erb
@@ -4,6 +4,15 @@
       <h1 class='page-header'>Edit Remote Clinic Lawyer</h1>
 
       <%= render 'form' %>
+
+      <% unless @remote_lawyer.remote_clinic_friends.empty? %>
+	    <div class="field">
+		  <%= label_tag :id, 'Assigned Friends', class: 'col-xs-12 control-label' %>
+		  <div class='col-md-9'>
+		    <%= collection_select(:user, :id, @remote_lawyer.remote_clinic_friends, :id, :name, {include_blank: true, class: 'form-control' }) %>
+		  </div>
+	    </div>
+	  <% end %>
     </div>
   </div>
 <div />

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -15,7 +15,7 @@ Devise.setup do |config|
   config.mailer_sender = ENV['FROM_ADDRESS']
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = 'Devise::Mailer'
 
   # Configure the parent class responsible to send e-mails.
   # config.parent_mailer = 'ActionMailer::Base'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,11 +78,7 @@ Rails.application.routes.draw do
     devise_for :users, only: [:invitations], controllers: { invitations: "invitations" }
     resources :regions, only: [] do
       resources :communities, only: [:index, :new, :create, :edit, :update]
-      resources :friends, only: [:index, :show] do
-        member do
-          post :assign_friendship
-        end
-      end
+      resources :friends, only: [:index, :show, :update]
     end
     resources :remote_lawyers, only: [:index, :destroy, :edit, :update]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,7 +78,11 @@ Rails.application.routes.draw do
     devise_for :users, only: [:invitations], controllers: { invitations: "invitations" }
     resources :regions, only: [] do
       resources :communities, only: [:index, :new, :create, :edit, :update]
-      resources :friends, only: [:index, :show]
+      resources :friends, only: [:index, :show] do
+        member do
+          post :assign_friendship
+        end
+      end
     end
     resources :remote_lawyers, only: [:index, :destroy, :edit, :update]
   end

--- a/spec/controllers/regional_admin_access/friends_controller_spec.rb
+++ b/spec/controllers/regional_admin_access/friends_controller_spec.rb
@@ -27,6 +27,17 @@ RSpec.describe RegionalAdmin::FriendsController, type: :controller do
         expect(response.success?).to eq true
       end
     end
+
+    describe 'POST #assign_friendship' do
+      let(:lawyer) { create(:user, :remote_clinic_lawyer) }
+      let(:friend) { create(:friend) }
+
+      it 'creates friendship' do
+        friendship_count = UserFriendAssociation.count
+        post :assign_friendship, params: { region_id: region.id, id: friend.id, user: {id: lawyer.id} }
+        expect(UserFriendAssociation.count).to eq friendship_count + 1
+      end
+    end
   end
 
   describe 'as a logged in community admin' do

--- a/spec/controllers/regional_admin_access/friends_controller_spec.rb
+++ b/spec/controllers/regional_admin_access/friends_controller_spec.rb
@@ -21,21 +21,19 @@ RSpec.describe RegionalAdmin::FriendsController, type: :controller do
       end
     end
 
-    describe 'GET #new' do
+    describe 'GET #show' do
       it 'allows access' do
         get :show, params: { region_id: region.id, id: friend.id }
         expect(response.success?).to eq true
       end
     end
 
-    describe 'POST #assign_friendship' do
-      let(:lawyer) { create(:user, :remote_clinic_lawyer) }
-      let(:friend) { create(:friend) }
-
-      it 'creates friendship' do
-        friendship_count = UserFriendAssociation.count
-        post :assign_friendship, params: { region_id: region.id, id: friend.id, user: {id: lawyer.id} }
-        expect(UserFriendAssociation.count).to eq friendship_count + 1
+    describe 'PUT #update' do
+      let(:user) { create :user, remote_clinic_lawyer: true }
+      it 'updates the friend' do
+        user_friend_association_count = UserFriendAssociation.count
+        put :update, params: { region_id: region.id, id: friend.id, friend: { user_ids: [user.id] } }
+        expect(UserFriendAssociation.count).to eq user_friend_association_count + 1
       end
     end
   end

--- a/spec/models/user_friend_association_spec.rb
+++ b/spec/models/user_friend_association_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe UserFriendAssociation, type: :model do
+  it { is_expected.to belong_to :friend }
+  it { is_expected.to belong_to :user }
+
+  describe 'creates remote relationship' do
+    let(:friend) { create(:friend) }
+    let(:user) { create(:user, :remote_clinic_lawyer) }
+
+    it 'sends email to remote lawyer' do
+      expect(FriendshipAssignmentMailer).to receive(:send_assignment).once
+      UserFriendAssociation.create(user: user, friend: friend, remote: true)
+    end
+  end
+end


### PR DESCRIPTION
## What
Adds dropdown for regional admins to assign a remote clinic lawyer to review a friend's application, creates the `user_friend_association`, then sends an email to the lawyer. It also adds a dropdown in the `remote_lawyer/edit` page to list the friends that the remote clinic lawyer is assigned to. The description of issue #16 only said to "show which friends the lawyer had access to." but let me know if it should do anything else.

I uncommented `config.mailer = 'Devise::Mailer'` in `initializers/devise.rb` so I can send a custom mailer. It seemed like magic how the other devise mailers are being sent out and this 

Below is a screenshot of what it looks like in development. It's not really styled but I figure that can come later :)
<img width="442" alt="screen shot 2018-06-27 at 5 34 40 pm" src="https://user-images.githubusercontent.com/4992773/42001272-7fe0bc98-7a31-11e8-9dbb-ed922a5e449b.png">


## Why
Issue #16 